### PR TITLE
docs: align site with 1.0.0a1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Not a Python user? Looking for leveraging the power of pyDIGGS in a modern web a
 
 ## Quick Start
 
-Install pydiggs:
+Install pydiggs (requires Python 3.11+):
 ```bash
 uv pip install pydiggs
 # or: pip install pydiggs
@@ -53,10 +53,13 @@ Basic usage with Python:
 ```python
 from pydiggs import detect_diggs_version, validator
 
-# Create a validator instance (profile auto-detected from the file namespace)
+# Profile auto-detected from the instance namespace (unknown → 3.0.0)
 validation = validator("path/to/your/diggs_file.xml")
 
-print(detect_diggs_version("path/to/your/diggs_file.xml"))
+print(detect_diggs_version("path/to/your/diggs_file.xml"))  # "2.5.a", "2.6", or "3.0.0"
+
+# Or pin a profile explicitly (Python API only)
+validation = validator("path/to/your/diggs_file.xml", diggs_version="2.6")
 
 # Schema validation
 validation.schema_check()
@@ -92,5 +95,9 @@ pydiggs context_check "path/to/your/diggs_file.xml"
 # Custom Schematron
 pydiggs schematron_check "path/to/your/diggs_file.xml" --schematron_path "path/to/schematron.sch"
 ```
+
+**1.0.0a1** is an alpha toward 1.0.0. See [usage](https://xinp-hub.github.io/pydiggs/usage/) for
+`diggs_version` / `schema_path` overrides, log output options, and [known limits](https://xinp-hub.github.io/pydiggs/usage/#known-limits)
+(dictionary check 12 as WARNING, bundled Schematron subset, and more).
 
 For more detailed information and advanced usage, please see the [documentation](https://xinp-hub.github.io/pydiggs).

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,12 +1,26 @@
 # History
 
-## Unreleased (1.0.0a1 track)
+## Unreleased
 
-* DIGGS **3.0.0** schemas + namespace auto-detect (unknown NS → 3.0.0).
-* FORGE packaging: src/, uv, hatchling; Trusted Publishing.
-* Full official diggs-examples corpus (2.5.a / 2.6 / 3.0 + known_invalid).
-* Fix 2.5.a auto-detect to use ``Complete.xsd``.
+No user-facing changes yet.
 
+## 1.0.0a1 (2026-08-07)
+
+Alpha release toward 1.0.0.
+
+* Added DIGGS **3.0.0** bundled schemas (`schema-dev@3.0.0`) and namespace
+  auto-detection (`detect_diggs_version`); unknown namespaces default to **3.0.0**.
+* Added full official [diggs-examples](https://github.com/DIGGSml/diggs-examples) corpus
+  under `tests/fixtures/official/` (2.5.a / 2.6 / 3.0 goldens + known_invalid pins).
+* Migrated packaging to FORGE standards: `src/` layout, **uv** + hatchling (not Poetry),
+  PEP 621/639/735; `requires-python` raised to **>=3.11**.
+* PyPI publish uses Trusted Publishing (OIDC) on `v*` tags.
+* DIGGS **2.5.a** auto-detect resolves bundled `Complete.xsd` (no `Diggs.xsd` in 2.5.a).
+* Dictionary validation prefers modern `def/codes/.../properties.xml` when instances cite
+  legacy URLs; accepts integer-family `typeData` aliases; maps common legacy fragments.
+* Schematron `weightRetained` assert allows zero, matching official grading examples.
+* **Note:** dictionary check 12 (UOM not in quantity class) is a WARNING so official
+  diggs-examples with known unit/quantity mismatches still pass `dictionary_check()`.
 
 ## 0.2.0 (2026-08-07)
 
@@ -17,7 +31,7 @@
 * New `context_check()` for Diggs structure, geometry SRS attributes, in-document xlink:href, and dataBlock arity.
 * CLI: `context_check`, `--dictionary_path`, default Schematron, `--output_log` / `--no-output_log`, nonzero exit on failure.
 * Official diggs-examples curated fixtures under `tests/fixtures/official/`.
-* Docs updated for Python ≥3.10 and current validation behavior.
+* Docs updated for current validation behavior (Python floor was 3.10 until 1.0.0a1).
 * CI: mypy ignores missing `lxml` stubs so typecheck matches the validation codebase.
 
 ## 0.1.5 (2025-02-02)

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ Not a Python user? Looking for leveraging the power of pyDIGGS in a modern web a
 
 ## Quick Start
 
-Install pydiggs:
+Install pydiggs (requires Python 3.11+):
 ```bash
 uv pip install pydiggs
 # or: pip install pydiggs
@@ -45,8 +45,12 @@ Basic usage with Python:
 ```python
 from pydiggs import detect_diggs_version, validator
 
+# Profile auto-detected from namespace (unknown → 3.0.0)
 validation = validator("path/to/your/diggs_file.xml")
-print(detect_diggs_version("path/to/your/diggs_file.xml"))
+print(detect_diggs_version("path/to/your/diggs_file.xml"))  # "2.5.a", "2.6", or "3.0.0"
+
+# Pin a profile (Python API only)
+validation = validator("path/to/your/diggs_file.xml", diggs_version="2.6")
 
 validation.schema_check()
 validation.dictionary_check()
@@ -62,4 +66,7 @@ pydiggs schematron_check "path/to/your/diggs_file.xml"
 pydiggs context_check "path/to/your/diggs_file.xml"
 ```
 
-For more detailed information and advanced usage, please see the [documentation](https://xinp-hub.github.io/pydiggs).
+**1.0.0a1** is an alpha toward 1.0.0. See [Usage](usage.md) for overrides, log options, and
+[known limits](usage.md#known-limits).
+
+For more detailed information and advanced usage, please see the [Usage guide](usage.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,7 @@ from pydiggs import detect_diggs_version, validator
 validation = validator("DIGGS_Instance_File_Path", output_log=True)
 validation = validator("DIGGS_Instance_File_Path", output_log=False)
 
-print(detect_diggs_version("DIGGS_Instance_File_Path"))  # e.g. "2.6" or "3.0.0"
+print(detect_diggs_version("DIGGS_Instance_File_Path"))  # "2.5.a", "2.6", or "3.0.0"
 ```
 
 ### 1. Schema Validation
@@ -58,6 +58,10 @@ print(validation.schema_error_log)  # schema parse errors
 ```
 
 #### Using Command Line Interface
+
+The CLI auto-detects the DIGGS profile from the instance namespace (unknown → 3.0.0).
+There is no `--diggs_version` flag; pin a profile in Python with `diggs_version=`, or pass
+`--schema_path` to a specific XSD.
 
 ```bash
 pydiggs schema_check "DIGGS_Instance_File_Path"
@@ -140,6 +144,7 @@ pydiggs context_check "DIGGS_Instance_File_Path" --no-output_log
 
 ### Known limits
 
+- **1.0.0a1** is an alpha toward 1.0.0; APIs and bundled assets may change before 1.0.0.
 - Official [diggs-examples](https://github.com/DIGGSml/diggs-examples) files under
   `tests/fixtures/official/known_invalid/` fail schema (or XML syntax) against the bundled
   XSDs; they are pinned so we never silently accept them.


### PR DESCRIPTION
## Summary
- Sync README / docs index / usage / history with published **1.0.0a1** (DIGGS 3.0 auto-detect, `diggs_version` override, Python 3.11+, known limits).
- `mkdocs build --strict` passes locally.

## Test plan
- [x] `uv run --group docs mkdocs build --strict`
- [ ] Confirm GitHub Pages deploy after merge


Made with [Cursor](https://cursor.com)