### PR TITLE
release: prepare 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-07
+
+Stable release of the DIGGS 3.0 + FORGE packaging train first shipped as 1.0.0a1.
+
+### Added
+- Everything from [1.0.0a1](#100a1---2026-08-07), now marked stable.
+- Documentation aligned with the public 1.0.0 API (`diggs_version` override, Python 3.11+,
+  four validation checks, known limits).
+
+### Notes
+- Dictionary check 12 (UOM not in quantity class) remains a **WARNING** so official
+  diggs-examples with known unit/quantity mismatches still pass `dictionary_check()`.
+- Unknown instance namespaces still default to DIGGS profile **3.0.0** (HG2).
+
 ## [1.0.0a1] - 2026-08-07
 
 ### Added
@@ -53,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - License Apache-2.0; optional log output CLI control; docs updates.
 
-[Unreleased]: https://github.com/xinp-hub/pydiggs/compare/v1.0.0a1...HEAD
+[Unreleased]: https://github.com/xinp-hub/pydiggs/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/xinp-hub/pydiggs/compare/v1.0.0a1...v1.0.0
 [1.0.0a1]: https://github.com/xinp-hub/pydiggs/compare/v0.2.0...v1.0.0a1
 [0.2.0]: https://github.com/xinp-hub/pydiggs/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/xinp-hub/pydiggs/releases/tag/v0.1.5

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ pydiggs context_check "path/to/your/diggs_file.xml"
 pydiggs schematron_check "path/to/your/diggs_file.xml" --schematron_path "path/to/schematron.sch"
 ```
 
-**1.0.0a1** is an alpha toward 1.0.0. See [usage](https://xinp-hub.github.io/pydiggs/usage/) for
-`diggs_version` / `schema_path` overrides, log output options, and [known limits](https://xinp-hub.github.io/pydiggs/usage/#known-limits)
+See [usage](https://xinp-hub.github.io/pydiggs/usage/) for `diggs_version` / `schema_path`
+overrides, log output options, and [known limits](https://xinp-hub.github.io/pydiggs/usage/#known-limits)
 (dictionary check 12 as WARNING, bundled Schematron subset, and more).
 
 For more detailed information and advanced usage, please see the [documentation](https://xinp-hub.github.io/pydiggs).

--- a/docs/history.md
+++ b/docs/history.md
@@ -4,6 +4,13 @@
 
 No user-facing changes yet.
 
+## 1.0.0 (2026-08-07)
+
+Stable release of the DIGGS 3.0 + FORGE packaging train first shipped as 1.0.0a1.
+
+* Everything from 1.0.0a1, now marked stable.
+* Documentation aligned with the public 1.0.0 API.
+
 ## 1.0.0a1 (2026-08-07)
 
 Alpha release toward 1.0.0.

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,6 @@ pydiggs schematron_check "path/to/your/diggs_file.xml"
 pydiggs context_check "path/to/your/diggs_file.xml"
 ```
 
-**1.0.0a1** is an alpha toward 1.0.0. See [Usage](usage.md) for overrides, log options, and
-[known limits](usage.md#known-limits).
+See [Usage](usage.md) for overrides, log options, and [known limits](usage.md#known-limits).
 
 For more detailed information and advanced usage, please see the [Usage guide](usage.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -144,7 +144,6 @@ pydiggs context_check "DIGGS_Instance_File_Path" --no-output_log
 
 ### Known limits
 
-- **1.0.0a1** is an alpha toward 1.0.0; APIs and bundled assets may change before 1.0.0.
 - Official [diggs-examples](https://github.com/DIGGSml/diggs-examples) files under
   `tests/fixtures/official/known_invalid/` fail schema (or XML syntax) against the bundled
   XSDs; they are pinned so we never silently accept them.

--- a/src/pydiggs/__init__.py
+++ b/src/pydiggs/__init__.py
@@ -15,6 +15,6 @@ from .pydiggs import validator
 
 __author__ = """Xin Peng"""
 __email__ = "xin_peng@outlook.com"
-__version__ = "1.0.0a1"
+__version__ = "1.0.0"
 
 __all__ = ["detect_diggs_version", "validator"]


### PR DESCRIPTION
## Summary
- Bump `__version__` to **1.0.0** (stable cut of the 1.0.0a1 train).
- CHANGELOG / history / README / usage / index updated for GA (no alpha caveats).
- Does **not** tag or publish — HG3/HG4 after merge.

## Test plan
- [x] `uv run pytest -q`
- [x] `uv run --group docs mkdocs build --strict`
- [ ] CI green
- [ ] After merge: HG3 digests + approve tag `v1.0.0` / push / `pypi` env


Made with [Cursor](https://cursor.com)