### PR TITLE
ci: Dependabot, security, and full Release publish path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  # Actions are the highest-risk dependency in a publishing repo: a compromised
+  # action runs with your OIDC identity. Keep them current and SHA-pinned.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    # Wait a week before proposing a new release. A compromised version is usually yanked
+    # within days — that is the window where a mechanical bump is most dangerous.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        patterns: ["*"]
+      runtime-minor-patch:
+        dependency-type: production
+        update-types: ["minor", "patch"]
+    # Runtime majors get their own PR: they may require a compatibility change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require every job success
+      - name: Fail if any required job failed or was cancelled
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
           set -euo pipefail
           echo "$NEEDS"
-          echo "$NEEDS" | grep -qE '"lint":\{[^}]*"result":"success"'
-          echo "$NEEDS" | grep -qE '"test":\{[^}]*"result":"success"'
-          echo "$NEEDS" | grep -qE '"build":\{[^}]*"result":"success"'
+          if echo "$NEEDS" | grep -qE '"result": "(failure|cancelled)"'; then
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
   lint:
     name: lint & types
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
@@ -43,6 +44,7 @@ jobs:
   test:
     name: test (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -62,6 +64,7 @@ jobs:
   build:
     name: build & inspect
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
@@ -90,10 +93,14 @@ jobs:
     if: always()
     needs: [lint, test, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Require every job success
+        env:
+          NEEDS: ${{ toJSON(needs) }}
         run: |
-          echo '${{ toJSON(needs) }}'
-          echo '${{ needs.lint.result }}' | grep -qx success
-          echo '${{ needs.test.result }}' | grep -qx success
-          echo '${{ needs.build.result }}' | grep -qx success
+          set -euo pipefail
+          echo "$NEEDS"
+          echo "$NEEDS" | grep -qE '"lint":\{[^}]*"result":"success"'
+          echo "$NEEDS" | grep -qE '"test":\{[^}]*"result":"success"'
+          echo "$NEEDS" | grep -qE '"build":\{[^}]*"result":"success"'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,43 +1,199 @@
 # Trusted Publishing (OIDC) — no API token.
-# PyPI pending/normal publisher must match:
+# Filename stays `publish.yml` so the existing PyPI pending/active publisher keeps working:
 #   owner: xinp-hub  repo: pydiggs  workflow: publish.yml  environment: pypi
-name: Publish to PyPI
+# Mirror that publisher on test.pypi.org with environment: testpypi.
+# Add required reviewers on the GitHub `pypi` Environment (optional on `testpypi`).
+#
+# Release path (FORGE): guard → build → TestPyPI → smoke → PyPI → Sigstore + GitHub Release.
+# `setup-uv` uses enable-cache: false on purpose (cache poisoning ↔ publish path).
+name: Release
 
 on:
   push:
     tags: ["v[0-9]+.[0-9]+.[0-9]+*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Build and check only; do not publish
+        type: boolean
+        default: true
 
 permissions:
   contents: read
 
 concurrency:
-  group: publish-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  publish:
+  guard:
+    name: verify tag matches package version
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/pydiggs/
-    permissions:
-      id-token: write
-      contents: read
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.check.outputs.version }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
         with:
+          python-version: "3.11"
           enable-cache: false
-          python-version: "3.12"
+      - id: check
+        name: Tag, __init__ and CHANGELOG must agree
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#v}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="$(uv run --no-project python -c "import re,pathlib;print(re.search(r'__version__ = \"([^\"]+)\"', pathlib.Path('src/pydiggs/__init__.py').read_text()).group(1))")"
+          fi
+          code="$(uv run --no-project python -c "import re,pathlib;print(re.search(r'__version__ = \"([^\"]+)\"', pathlib.Path('src/pydiggs/__init__.py').read_text()).group(1))")"
+          if [ "$tag" != "$code" ]; then
+            echo "::error::tag v$tag does not match __version__ $code"
+            exit 1
+          fi
+          if ! grep -qE "^## \[$tag\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no released section for $tag"
+            exit 1
+          fi
+          echo "version=$tag" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: build distributions
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
+        with:
+          python-version: "3.11"
+          enable-cache: false
       - name: Build
         run: |
           export SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
           uv build
-      - name: Record digests
-        run: sha256sum dist/* | tee dist-digests.txt
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
+      - name: Check and record digests
+        run: |
+          uv run --group audit twine check --strict dist/*
+          uv run --group audit check-wheel-contents dist/*.whl
+          sha256sum dist/* | tee dist-digests.txt
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: distributions
+          path: |
+            dist/
+            dist-digests.txt
+          if-no-files-found: error
+
+  testpypi:
+    name: publish to TestPyPI
+    needs: build
+    if: github.event_name == 'push' || !inputs.dry_run
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/pydiggs/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: distributions
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          attestations: true
+
+  smoke:
+    name: install from TestPyPI
+    needs: [guard, testpypi]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
+        with:
+          python-version: "3.11"
+          enable-cache: false
+      - name: Install the published artifact and import it
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5 6; do
+            if uv pip install --system \
+                 --index-strategy unsafe-best-match \
+                 --extra-index-url https://test.pypi.org/simple/ \
+                 "pydiggs==${VERSION}"; then
+              break
+            fi
+            echo "index not ready yet (attempt $attempt); waiting"
+            sleep 20
+          done
+          python -c "import pydiggs as m; assert m.__version__ == '${VERSION}', m.__version__; print('smoke ok', m.__version__)"
+
+  pypi:
+    name: publish to PyPI
+    needs: [build, smoke]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pydiggs/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: distributions
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
         with:
           attestations: true
+
+  github-release:
+    name: GitHub release
+    needs: [guard, pypi]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: distributions
+      - name: Sign the distributions with Sigstore
+        uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46  # v3.0.0
+        with:
+          inputs: ./dist/*.tar.gz ./dist/*.whl
+      - name: Create the release from the changelog section
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          set -euo pipefail
+          awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" {p=1; next}
+            p && /^## \[/ {exit}
+            p {print}
+          ' CHANGELOG.md > notes.md
+          printf '\n---\nPyPI: https://pypi.org/project/pydiggs/%s/\n' "$VERSION" >> notes.md
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; uploading assets only"
+            gh release upload "$GITHUB_REF_NAME" dist/* dist-digests.txt --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "pydiggs $VERSION" \
+              --notes-file notes.md \
+              --verify-tag \
+              dist/* dist-digests.txt
+          fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,105 @@
+# Supply-chain and code scanning (FORGE security.yml adapted for branch `master`).
+name: Security
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: dependency audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
+        with:
+          enable-cache: true
+          python-version: "3.11"
+      - run: uv sync --all-groups
+        env:
+          UV_FROZEN: "1"
+      - name: pip-audit
+        run: uv run --group audit pip-audit --strict --progress-spinner=off
+
+  dependency-review:
+    name: dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+        with:
+          languages: python
+          queries: security-extended
+      - uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+
+  secret-scan:
+    name: secret scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+
+  all-green:
+    name: all green
+    if: always()
+    needs: [audit, dependency-review, codeql, secret-scan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS"
+          if echo "$NEEDS" | grep -qE '"result": "(failure|cancelled)"'; then
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- FORGE-aligned **Release** workflow (`publish.yml`): tag/CHANGELOG guard, artifact handoff,
+  TestPyPI + smoke install, PyPI attestations, Sigstore signing, GitHub Release creation.
+- `security.yml` (pip-audit, dependency-review, CodeQL, gitleaks) and Dependabot for `uv` +
+  GitHub Actions (weekly, 7-day cooldown).
+
+### Changed
+- CI jobs gain `timeout-minutes`; the `all green` gate reads `needs` via `env` (safer than
+  interpolating into `run:`).
+- Docs known limits link dictionary follow-ups to issues
+  [#220](https://github.com/xinp-hub/pydiggs/issues/220) and
+  [#221](https://github.com/xinp-hub/pydiggs/issues/221).
+
 ## [1.0.0] - 2026-08-07
 
 Stable release of the DIGGS 3.0 + FORGE packaging train first shipped as 1.0.0a1.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Downloads/Month](https://static.pepy.tech/badge/pydiggs/month)](https://pepy.tech/project/pydiggs)
 [![Build Status](https://github.com/xinp-hub/pydiggs/actions/workflows/ci.yml/badge.svg)](https://github.com/xinp-hub/pydiggs/actions/workflows/ci.yml)
 [![Documentation Status](https://github.com/xinp-hub/pydiggs/actions/workflows/docs.yml/badge.svg)](https://xinp-hub.github.io/pydiggs/)
-[![Updates](https://pyup.io/repos/github/xinp-hub/pydiggs/shield.svg)](https://pyup.io/account/repos/github/xinp-hub/pydiggs/)
 [![GitHub Issues](https://img.shields.io/github/issues/xinp-hub/pydiggs.svg)](https://github.com/xinp-hub/pydiggs/issues)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -147,8 +147,13 @@ pydiggs context_check "DIGGS_Instance_File_Path" --no-output_log
 - Official [diggs-examples](https://github.com/DIGGSml/diggs-examples) files under
   `tests/fixtures/official/known_invalid/` fail schema (or XML syntax) against the bundled
   XSDs; they are pinned so we never silently accept them.
-- Dictionary check 12 (UOM/quantity mismatch) is reported as WARNING so those examples still
-  pass `dictionary_check()` with a visible advisory.
+- Dictionary check 12 (UOM/quantity mismatch) is reported as **WARNING** so those examples
+  still pass `dictionary_check()` with a visible advisory. Tracking:
+  [#220](https://github.com/xinp-hub/pydiggs/issues/220).
+- Some DIGGS 3.x example property codes are satisfied by **local dictionary supplements**
+  until the official DIGGS property dictionary grows them. Tracking:
+  [#221](https://github.com/xinp-hub/pydiggs/issues/221). Prefer contributing definitions
+  upstream over growing the local supplement file when official vocabularies accept them.
 - Legacy `http://diggsml.org/dictionaries/DIGGSTestPropertyDefinitions.xml#…` codeSpaces are
   resolved against the modern `def/codes/DIGGS/0.1/properties.xml` definitions when present.
 - Upstream Schematron `queryBinding="xslt3"` rules that call remote APIs are not executed by


### PR DESCRIPTION
## Summary
- Add weekly **Dependabot** for `uv` + GitHub Actions (7-day cooldown).
- Add **security.yml**: pip-audit, dependency-review, CodeQL, gitleaks.
- Expand **publish.yml** to the FORGE Release path (filename unchanged for Trusted Publishing): guard → build → TestPyPI → smoke → PyPI → Sigstore + GitHub Release.
- Soften CI (`timeout-minutes`, safer `all green` env usage); drop stale pyup badge.
- Docs/changelog for dictionary maintain tracking: #220, #221.

## Test plan
- [ ] CI + Security workflows green on this PR
- [ ] Confirm GitHub Environment `testpypi` + TestPyPI Trusted Publisher still match `publish.yml`
- [ ] Optional dry-run: Actions → Release → `workflow_dispatch` with `dry_run=true` after merge


Made with [Cursor](https://cursor.com)