### PR TITLE
chore: mailmap Cursor Agent off the contributors list

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+# Canonical author mapping for git shortlog / GitHub Contributors.
+# Maps Cursor Agent Co-authored-by trailers to the maintainer identity so
+# cursoragent does not appear as a separate contributor. See gitmailmap(5).
+#
+# Canonical form must use the GitHub noreply address linked to xinp-hub.
+Xin Peng <83672198+xinp-hub@users.noreply.github.com> <cursoragent@cursor.com>
+Xin Peng <83672198+xinp-hub@users.noreply.github.com> Cursor <cursoragent@cursor.com>


### PR DESCRIPTION
## Summary
- Add `.mailmap` remapping `cursoragent@cursor.com` / `Cursor <cursoragent@cursor.com>` to `Xin Peng <83672198+xinp-hub@users.noreply.github.com>`.
- GitHub-supported way to drop Cursor Agent from **Contributors** without rewriting history (Co-authored-by trailers stay in messages; display attribution changes).

## Local prevention (not in this PR)
- CLI: `~/.cursor/cli-config.json` → attribution flags false
- IDE: Attribution toggles off
- Clone-local `prepare-commit-msg` hook strips Cursor trailers if they reappear

## Test plan
- [x] `git check-mailmap 'Cursor <cursoragent@cursor.com>'` → Xin Peng noreply
- [ ] Merge to `master`
- [ ] Within a few hours, confirm contributors no longer lists Cursor Agent (pyup-bot unchanged)


Made with [Cursor](https://cursor.com)