### PR TITLE
fix: restore check-12 ERROR and inventory DIGGS supplements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Correct `t50` UOM on three vendored DIGGS 2.6 pore-pressure fixtures (`kPa` → `s`)
+  so they match the 3.0 example ([#220](https://github.com/xinp-hub/pydiggs/issues/220);
+  upstream [DIGGSml/diggs-examples#4](https://github.com/DIGGSml/diggs-examples/issues/4)).
+- Dictionary check 12 treats DIGGS 2.6 AllUnits spelling `cm2/m` as `cm2/min` (Kernel.xsd
+  documents it as square centimeter per minute).
 - Release workflow skips republish when the tag version is already on PyPI (avoids
   red `pypi` Environment deployments after intentional tag retargets).
 
 ### Added
+- `pydiggs.dictionaries.supplements` inventory of MWD/Pile codes required by 3.0 goldens
+  and tracked upstream ([#221](https://github.com/xinp-hub/pydiggs/issues/221);
+  [DIGGSml/def#13](https://github.com/DIGGSml/def/issues/13) /
+  [#14](https://github.com/DIGGSml/def/issues/14)).
 - FORGE-aligned **Release** workflow (`publish.yml`): tag/CHANGELOG guard, artifact handoff,
   TestPyPI + smoke install, PyPI attestations, Sigstore signing, GitHub Release creation.
 - `security.yml` (pip-audit, dependency-review, CodeQL, gitleaks) and Dependabot for `uv` +
   GitHub Actions (weekly, 7-day cooldown).
 
 ### Changed
+- Dictionary check 12 (UOM not in quantity class) is an **ERROR** again now that the
+  official corpus goldens no longer require the advisory workaround. Instances that used
+  invalid UOMs and previously only warned will now fail `dictionary_check()`.
 - CI/docs/security/Release Actions refreshed to current majors with commit SHA pins
   (`checkout` v7, `setup-uv` v9, artifact upload/download v7/v8, CodeQL v4,
   dependency-review v5, `actions-gh-pages` v4, Sigstore action v3.5).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -147,13 +147,17 @@ pydiggs context_check "DIGGS_Instance_File_Path" --no-output_log
 - Official [diggs-examples](https://github.com/DIGGSml/diggs-examples) files under
   `tests/fixtures/official/known_invalid/` fail schema (or XML syntax) against the bundled
   XSDs; they are pinned so we never silently accept them.
-- Dictionary check 12 (UOM/quantity mismatch) is reported as **WARNING** so those examples
-  still pass `dictionary_check()` with a visible advisory. Tracking:
-  [#220](https://github.com/xinp-hub/pydiggs/issues/220).
+- Dictionary check 12 (UOM/quantity mismatch) is an **ERROR**. Three 2.6 pore-pressure
+  fixtures correct `t50` to `s`; `coef_consolidation_horiz` keeps the 2.6 AllUnits
+  spelling `cm2/m`, which check 12 aliases to `cm2/min`. Upstream:
+  [DIGGSml/diggs-examples#4](https://github.com/DIGGSml/diggs-examples/issues/4);
+  see `tests/fixtures/official/PROVENANCE.txt`.
 - Some DIGGS 3.x example property codes are satisfied by **local dictionary supplements**
-  until the official DIGGS property dictionary grows them. Tracking:
-  [#221](https://github.com/xinp-hub/pydiggs/issues/221). Prefer contributing definitions
-  upstream over growing the local supplement file when official vocabularies accept them.
+  (`mwd_properties.xml`, `pil_properties.xml`) until
+  [DIGGSml/def#13](https://github.com/DIGGSml/def/issues/13) /
+  [#14](https://github.com/DIGGSml/def/issues/14) publish them. The golden code inventory is
+  `pydiggs.dictionaries.supplements`. Prefer contributing definitions upstream over growing
+  the local supplement files when official vocabularies accept them.
 - Legacy `http://diggsml.org/dictionaries/DIGGSTestPropertyDefinitions.xml#…` codeSpaces are
   resolved against the modern `def/codes/DIGGS/0.1/properties.xml` definitions when present.
 - Upstream Schematron `queryBinding="xslt3"` rules that call remote APIs are not executed by

--- a/src/pydiggs/dictionaries/supplements.py
+++ b/src/pydiggs/dictionaries/supplements.py
@@ -1,0 +1,49 @@
+"""Inventory of local DIGGS dictionary supplements required by official 3.0 goldens.
+
+These codes live in ``codes/mwd_properties.xml`` / ``codes/pil_properties.xml`` and are
+not present in the primary ``properties.xml``. Track upstream so the local bundle can
+shrink when diggsml.org/def publishes replacements:
+
+* MWD — https://github.com/DIGGSml/def/issues/13
+* Pile-driving — https://github.com/DIGGSml/def/issues/14
+* Downstream tracker — https://github.com/xinp-hub/pydiggs/issues/221
+"""
+
+from __future__ import annotations
+
+# Codes referenced by tests/fixtures/official/3.0/MWDExample.xml that are absent from
+# properties.xml (fragment ids on mwd_properties.xml).
+MWD_GOLDEN_CODES: frozenset[str] = frozenset(
+    {
+        "event_new_rod",
+        "fluid_injection_pressure",
+        "fluid_injection_volume_rate",
+        "holdback_pressure",
+        "hydraulic_crowd_pressure",
+        "hydraulic_torque_pressure",
+        "penetration_rate",
+        "rotation_shaft",
+    }
+)
+
+# Codes referenced by tests/fixtures/official/3.0/PileDrivingExample.xml that are absent
+# from properties.xml (fragment ids on pil_properties.xml).
+PIL_GOLDEN_CODES: frozenset[str] = frozenset(
+    {
+        "bl_no",
+        "bpm",
+        "csx_avg",
+        "csx_max",
+        "csx_min",
+        "emx_avg",
+        "emx_max",
+        "emx_min",
+        "rmx_avg",
+        "rmx_max",
+        "rmx_min",
+        "stroke",
+        "tsx_avg",
+        "tsx_max",
+        "tsx_min",
+    }
+)

--- a/src/pydiggs/dictionary.py
+++ b/src/pydiggs/dictionary.py
@@ -45,6 +45,12 @@ _PROPERTY_FRAGMENT_ALIASES = {
     "pore_water_pressure": "pore_pressure_u2",
 }
 
+# DIGGS 2.6 AllUnits uses abbreviated spellings that DiggsUomDictionary expands
+# (Kernel.xsd documents cm2/m as "square centimeter per minute").
+_UOM_ALIASES = {
+    "cm2/m": "cm2/min",
+}
+
 # XSD integer-family tokens accepted interchangeably for DIGGS typeData / dataType.
 _INTEGER_DATA_TYPES = frozenset(
     {
@@ -788,15 +794,14 @@ class DictionarySemanticValidator:
             )
             return
 
-        if uom_value not in allowed:
+        canonical_uom = _UOM_ALIASES.get(uom_value, uom_value)
+        if canonical_uom not in allowed and uom_value not in allowed:
             preview = ", ".join(sorted(allowed)[:15])
             extra = len(allowed) - 15
             if extra > 0:
                 preview = f"{preview}, ... and {extra} more"
-            # Advisory: official diggs-examples include known UOM/quantity mismatches
-            # (e.g. t50 with kPa). Keep the finding visible without failing the check.
             result.add(
-                "WARNING",
+                "ERROR",
                 path,
                 (
                     f'Check 12:\nThe unit of measure "{uom_value}" is not valid for quantity '

--- a/tests/fixtures/official/2.6/CPT_and_PorePressureDissipation.xml
+++ b/tests/fixtures/official/2.6/CPT_and_PorePressureDissipation.xml
@@ -1774,7 +1774,7 @@
                                             <propertyName>t50 (s)</propertyName>
                                             <typeData>double</typeData>
                                             <propertyClass codeSpace="http://diggsml.org/dictionaries/DIGGSTestPropertyDefinitions.xml#t50">t50</propertyClass>
-                                            <uom>kPa</uom>
+                                            <uom>s</uom>
                                             <reportable>true</reportable>
                                         </Property>
                                         <Property index="4" gml:id="ppd1-p5">

--- a/tests/fixtures/official/2.6/PorePressureDissipation.xml
+++ b/tests/fixtures/official/2.6/PorePressureDissipation.xml
@@ -1774,7 +1774,7 @@
                                             <propertyName>t50 (s)</propertyName>
                                             <typeData>double</typeData>
                                             <propertyClass codeSpace="http://diggsml.org/dictionaries/DIGGSTestPropertyDefinitions.xml#t50">t50</propertyClass>
-                                            <uom>kPa</uom>
+                                            <uom>s</uom>
                                             <reportable>true</reportable>
                                         </Property>
                                         <Property index="4" gml:id="ppd1-p5">

--- a/tests/fixtures/official/2.6/PorePressureDissipationOnly.xml
+++ b/tests/fixtures/official/2.6/PorePressureDissipationOnly.xml
@@ -62,7 +62,7 @@
                                             <propertyName>t50 (s)</propertyName>
                                             <typeData>double</typeData>
                                             <propertyClass codeSpace="http://diggsml.org/dictionaries/DIGGSTestPropertyDefinitions.xml#t50">t50</propertyClass>
-                                            <uom>kPa</uom>
+                                            <uom>s</uom>
                                             <reportable>true</reportable>
                                         </Property>
                                         <Property index="4" gml:id="ppd1-p5">

--- a/tests/fixtures/official/PROVENANCE.txt
+++ b/tests/fixtures/official/PROVENANCE.txt
@@ -7,3 +7,12 @@ Layout:
   known_invalid/ — official examples that are not acceptable Diggs documents
                    (schema fail, XML syntax error, or non-Diggs GML root accepted
                    only via Diggs.xsd GML imports — rejected via context_check)
+
+Local corrections (tracked upstream; drop when diggs-examples merges them):
+  2.6/PorePressureDissipationOnly.xml
+  2.6/PorePressureDissipation.xml
+  2.6/CPT_and_PorePressureDissipation.xml
+    — t50 uom kPa → s (matches 3.0 example; DIGGSml/diggs-examples#4)
+    — coef_consolidation_horiz keeps schema AllUnits spelling cm2/m (2.6 Kernel.xsd
+      documents this as cm²/minute); dictionary check 12 aliases cm2/m → cm2/min
+

--- a/tests/test_cli_and_corpus.py
+++ b/tests/test_cli_and_corpus.py
@@ -180,3 +180,36 @@ def test_schematron_and_dictionary_on_diggs_30_cli():
     assert main(["dictionary_check", path, "--no-output_log"]) == 0
     assert main(["schematron_check", path, "--no-output_log"]) == 0
     assert main(["context_check", path, "--no-output_log"]) == 0
+
+
+def test_pore_pressure_26_fixtures_have_no_check12():
+    """Local UOM corrections for #220 — no check-12 findings on the three 2.6 files."""
+    from pydiggs.dictionary import DictionarySemanticValidator
+
+    names = (
+        "PorePressureDissipationOnly.xml",
+        "PorePressureDissipation.xml",
+        "CPT_and_PorePressureDissipation.xml",
+    )
+    validator_sem = DictionarySemanticValidator()
+    for name in names:
+        result = validator_sem.validate_instance(FIXTURES / "2.6" / name)
+        assert not any(m.check == 12 for m in result.messages), name
+
+
+def test_supplement_codes_cover_30_goldens():
+    """#221: MWD/Pile golden codes live only in specialized dicts, not properties.xml."""
+    import re
+
+    from pydiggs.dictionaries.supplements import MWD_GOLDEN_CODES, PIL_GOLDEN_CODES
+
+    def gml_ids(path: Path) -> set[str]:
+        return set(re.findall(r'gml:id="([^"]+)"', path.read_text(encoding="utf-8")))
+
+    main = gml_ids(_PKG / "dictionaries" / "properties.xml")
+    mwd = gml_ids(_PKG / "dictionaries" / "codes" / "mwd_properties.xml")
+    pil = gml_ids(_PKG / "dictionaries" / "codes" / "pil_properties.xml")
+    assert MWD_GOLDEN_CODES.isdisjoint(main)
+    assert mwd >= MWD_GOLDEN_CODES
+    assert PIL_GOLDEN_CODES.isdisjoint(main)
+    assert pil >= PIL_GOLDEN_CODES

--- a/tests/test_pydiggs.py
+++ b/tests/test_pydiggs.py
@@ -214,8 +214,8 @@ def test_property_fragment_alias_pore_water_pressure(tmp_path):
     assert not any(m.severity == "ERROR" and m.check in {5, 10} for m in result.messages)
 
 
-def test_invalid_uom_is_warning_not_error(tmp_path):
-    """Check 12 UOM/quantity mismatches are advisory (WARNING), not ERROR."""
+def test_invalid_uom_is_error(tmp_path):
+    """Check 12 UOM/quantity mismatches fail dictionary_check (ERROR)."""
     inst = tmp_path / "t50.xml"
     inst.write_text(
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -248,5 +248,43 @@ def test_invalid_uom_is_warning_not_error(tmp_path):
         encoding="utf-8",
     )
     result = DictionarySemanticValidator().validate_instance(inst)
-    assert any(m.severity == "WARNING" and m.check == 12 for m in result.messages)
-    assert not any(m.severity == "ERROR" and m.check == 12 for m in result.messages)
+    assert any(m.severity == "ERROR" and m.check == 12 for m in result.messages)
+    assert result.ok is False
+
+
+def test_diggs26_cm2_m_aliases_to_cm2_min(tmp_path):
+    """2.6 AllUnits spelling cm2/m is accepted for area-per-time (alias → cm2/min)."""
+    inst = tmp_path / "ch.xml"
+    inst.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<Diggs xmlns="http://diggsml.org/schemas/2.6" xmlns:gml="http://www.opengis.net/gml/3.2" gml:id="t">
+  <measurement>
+    <Test gml:id="t1">
+      <outcome>
+        <TestResult gml:id="tr1">
+          <results>
+            <ResultSet gml:id="rs1">
+              <parameters>
+                <PropertyParameters gml:id="pp1">
+                  <properties>
+                    <Property gml:id="p1">
+                      <propertyClass codeSpace="https://diggsml.org/def/codes/DIGGS/0.1/properties.xml#coef_consolidation_horiz">ch</propertyClass>
+                      <typeData>double</typeData>
+                      <uom>cm2/m</uom>
+                    </Property>
+                  </properties>
+                </PropertyParameters>
+              </parameters>
+            </ResultSet>
+          </results>
+        </TestResult>
+      </outcome>
+    </Test>
+  </measurement>
+</Diggs>
+""",
+        encoding="utf-8",
+    )
+    result = DictionarySemanticValidator().validate_instance(inst)
+    assert not any(m.check == 12 for m in result.messages)
+    assert result.ok is True


### PR DESCRIPTION
## Summary
- **#220:** Correct vendored 2.6 `t50` UOM (`kPa`→`s`); alias DIGGS 2.6 `cm2/m`→`cm2/min` in check 12; restore check 12 as **ERROR** (HG2: invalid UOMs fail `dictionary_check()` again).
- **#221:** Add `pydiggs.dictionaries.supplements` inventory for MWD/Pile golden codes; regression tests pin specialized dict coverage.
- Docs / CHANGELOG / PROVENANCE updated; upstream diggs-examples#4 clarified.

## Test plan
- [ ] CI green
- [ ] `uv run pytest tests/test_pydiggs.py tests/test_cli_and_corpus.py` green locally
- [ ] After merge: close #220 and #221 with links to this PR